### PR TITLE
fixes a player destroy message issue

### DIFF
--- a/Server.cs
+++ b/Server.cs
@@ -108,12 +108,12 @@ public class Server : Node
     Node2D thePlayerToRemove = playerObjects[UUID];
     PlayerShip thePlayer = thePlayerToRemove.GetNode<PlayerShip>("PlayerShip");
 
+    // create the buffer for the specific player and send it
+    EntityGameEventBuffer egeb = thePlayer.CreatePlayerGameEventBuffer(EntityGameEventBuffer.EntityGameEventBufferType.Destroy);
+
     // TODO: should this get wrapped with a try or something?
     thePlayerToRemove.QueueFree();
     playerObjects.Remove(UUID);
-
-    // create the buffer for the specific player and send it
-    EntityGameEventBuffer egeb = thePlayer.CreatePlayerGameEventBuffer(EntityGameEventBuffer.EntityGameEventBufferType.Destroy);
 
     // send the player create event message
     MessageInterface.SendGameEvent(egeb);


### PR DESCRIPTION
Previously we were likely sending messages for players that were already reaped, causing strange explosions/exits in the server.